### PR TITLE
Fixed error about not all code paths return a value (CS0161)

### DIFF
--- a/src/Parser/YeSqlParser.HelperMethods.cs
+++ b/src/Parser/YeSqlParser.HelperMethods.cs
@@ -4,36 +4,42 @@ using System.Text;
 
 namespace YeSql.Net;
 
-/// <inheritdoc cref="YeSqlParser"/>
+// This class defines the private (or internal) helper methods.
 public partial class YeSqlParser
 {
-	/// <summary>
-	/// Determines if a line of text is a comment line that does not contain a tag.
-	/// </summary>
-	/// <param name="line">The line of text to check.</param>
-	/// <returns>True if the line is a comment without a tag, false otherwise.</returns>
-	private bool IsCommentWithoutTag(string line)
+    /// <summary>
+    /// Checks if the line of text is a comment without a tag.
+    /// </summary>
+    /// <param name="line">The line of text to validate.</param>
+    /// <returns><c>true</c> if the line is a comment without a tag, otherwise <c>false</c>.</returns>
+	/// <example>
+	/// -- This is a comment.
+	/// </example>
+    private bool IsCommentWithoutTag(string line)
 	{
-
+		throw new NotImplementedException();
 	}
 
-	/// <summary>
-	/// Determines if a line of text is a comment line that contains a tag.
-	/// </summary>
-	/// <param name="line">The line of text to check.</param>
-	/// <returns>True if the line is a comment with a tag, false otherwise.</returns>
-	private bool IsCommentWithTag(string line)
+    /// <summary>
+    /// Checks if the line of text is a comment with tag.
+    /// </summary>
+    /// <param name="line">The line of text to validate.</param>
+    /// <returns><c>true</c> if the line is a comment with tag, otherwise <c>false</c>.</returns>
+    /// <example>
+	/// -- name: This is a comment with tag.
+	/// </example>
+    private bool IsCommentWithTag(string line)
 	{
+        throw new NotImplementedException();
+    }
 
-	}
-
-	/// <summary>
-	/// Extracts the tag name from a line of text that is a comment with a tag.
-	/// </summary>
-	/// <param name="line">The line of text to extract the tag name from.</param>
-	/// <returns>The name of the tag, or an empty string if no tag name could be extracted.</returns>
-	private string ExtractTagName(string line)
+    /// <summary>
+    /// Extracts the tag name from a comment.
+    /// </summary>
+    /// <param name="line">The line with the tag name.</param>
+    /// <returns>The tag name extracted.</returns>
+    private string ExtractTagName(string line)
 	{
-
-	}
+        throw new NotImplementedException();
+    }
 }

--- a/src/Parser/YeSqlParser.cs
+++ b/src/Parser/YeSqlParser.cs
@@ -1,37 +1,44 @@
 ﻿using System;
 
-
 namespace YeSql.Net;
 
 /// <summary>
-/// A partial class that contains methods and properties related to parsing and validating SQL statements in a YeSQL file.
+/// Represents the parser that extracts the SQL statements from the tags.
 /// </summary>
 public partial class YeSqlParser
 {
     /// <summary>
-    /// A dictionary containing the SQL statements that have been parsed from the source code.
+    /// Gets the dictionary containing the SQL statements that have been parsed from the data source (e.g., a SQL file).
     /// </summary>
-    private YeSqlDictionary _sqlStatements;
+    internal YeSqlDictionary SqlStatements { get; } = new();
 
     /// <summary>
-    /// The result of the validation performed on the SQL statements.
+    /// Gets the result of the validation performed on the SQL statements.
     /// </summary>
-    internal YeSqlValidationResult validationResult;
+    internal YeSqlValidationResult ValidationResult { get; } = new();
 
     /// <summary>
-    /// The name of the file from which the SQL statements were parsed.
+    /// Gets the name of the file from which the SQL statements were parsed.
     /// </summary>
-    internal string sqlFileName;
+    internal string SqlFileName { get; }
 
     /// <summary>
-    /// Parses an SQL file and returns a collection of SQL statements.
+    /// Start the parsing to extract the SQL statements from a data source.
     /// </summary>
-    /// <param name="source">The source code of the SQL file to parse.</param>
-    /// <param name="result">The validation result of the parsing process.</param>
-    /// <returns>A collection of SQL statements.</returns>
-    public IYeSqlCollection Parse(string source, YeSqlValidationResult result)
+    /// <param name="source">The data source to parsing.</param>
+    /// <returns>A collection containing the tags with their associated SQL statements.</returns>
+    /// <exception cref="ArgumentNullException"><c>source</c> is <c>null</c>.</exception>
+    internal IYeSqlCollection Parse(string source)
+        => Parse(source, out _);
+
+    /// <inheritdoc cref="Parse(string)" />
+    /// <param name="validationResult">The validation result of the parsing process.</param>
+    public IYeSqlCollection Parse(string source, out YeSqlValidationResult validationResult)
     {
+        if(source is null)
+            throw new ArgumentNullException(nameof(source));
 
+        validationResult = ValidationResult;
+        return SqlStatements;
     }
-
 }


### PR DESCRIPTION
Some additional changes that were made to the `YeSqlParser` class:

* Updated XML comments

* Fields were converted to internal properties

* Added YeSqlParser.Parse without the ValidationResult parameter