### PR TITLE
Added support for init only setters

### DIFF
--- a/src/Models/SqlFile.cs
+++ b/src/Models/SqlFile.cs
@@ -12,10 +12,10 @@ internal struct SqlFile
     /// <summary>
     /// Gets or sets the file name of the SQL file.
     /// </summary>
-    public string FileName { get; set; }
+    public string FileName { get; init; }
 
     /// <summary>
     /// Gets or sets the content of the SQL file.
     /// </summary>
-    public string Content { get; set; }
+    public string Content { get; init; }
 }

--- a/src/Models/TagModel.cs
+++ b/src/Models/TagModel.cs
@@ -8,12 +8,12 @@ public struct TagModel
     /// <summary>
     /// Gets the name of the tag.
     /// </summary>
-    public string Name { get; set; }
+    public string Name { get; init; }
 
     /// <summary>
     /// Gets the SQL statement of the tag.
     /// </summary>
-    public string SqlStatement { get; set; }
+    public string SqlStatement { get; init; }
 
     /// <summary>
     /// Deconstructs the current <see cref="TagModel" />.

--- a/src/YeSql.Net.csproj
+++ b/src/YeSql.Net.csproj
@@ -5,4 +5,11 @@
 	  <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Added `IsExternalInit` package.
  - This package only includes the `IsExternalInit` type to be able to use the `init` keyword.
    For more information: https://github.com/manuelroemer/IsExternalInit.