### PR TITLE
fix: Prevent tests from failing since PR #97

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="YeSql.Net" Version="0.6.0-alpha" />
+    <PackageVersion Include="YeSql.Net" Version="0.7.0-alpha" />
     <PackageVersion Include="CopySqlFilesToOutputDirectory" Version="0.2.0-alpha" />
     <PackageVersion Include="CopySqlFilesToPublishDirectory" Version="0.1.0-alpha" />
     <PackageVersion Include="CPlugin.Net" Version="1.0.0" />

--- a/samples/Example.PluginApp/Plugins/EmployeePlugin/EmployeeSqlService.cs
+++ b/samples/Example.PluginApp/Plugins/EmployeePlugin/EmployeeSqlService.cs
@@ -2,7 +2,7 @@
 
 namespace PluginApp.EmployeePlugin;
 
-public class EmployeeSqlService(IYeSqlCollection sqlCollection)
+public class EmployeeSqlService(ISqlCollection sqlCollection)
 {
     public string GetSqlCode()
         => sqlCollection["GetEmployees"];

--- a/samples/Example.PluginApp/Plugins/UserPlugin/UserSqlService.cs
+++ b/samples/Example.PluginApp/Plugins/UserPlugin/UserSqlService.cs
@@ -2,7 +2,7 @@
 
 namespace PluginApp.UserPlugin;
 
-public class UserSqlService(IYeSqlCollection sqlCollection)
+public class UserSqlService(ISqlCollection sqlCollection)
 {
     public string GetSqlCode()
         => sqlCollection["GetUsers"];


### PR DESCRIPTION
This PR makes the tests in PR #97 run successfully.

**The main error is:**
> Error while validating the service descriptor 'ServiceType: PluginApp.UserPlugin.UserSqlService Lifetime: Transient ImplementationType: PluginApp.UserPlugin.UserSqlService': Could not load type 'YeSql.Net.IYeSqlCollection' from assembly 'YeSql.Net, Version=0.6.0.0, Culture=neutral, PublicKeyToken=null'.)

This happens because the host application uses the newer YeSql API (it does not have the IYeSqlCollection type) and the plugins use version 0.6.0-alpha.
The solution is to update the version to 0.7.0-alpha.