### PR TITLE
chore: Runs tests from the specified assemblied

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -23,11 +23,11 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Test 
       run: |
-       dotnet test ./tests/YeSql.Net.Tests.csproj
-       dotnet test ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj
-       dotnet publish ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj -c Debug -o out
+       dotnet test ./tests/YeSql.Net.Tests.csproj -c Release
+       dotnet test ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj -c Release
+       dotnet publish ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj -c Release -o out
        dotnet vstest ./out/Example.AspNetCore.Tests.dll
-       dotnet build ./samples/Example.PluginApp/Plugins/EmployeePlugin/PluginApp.EmployeePlugin.csproj
-       dotnet build ./samples/Example.PluginApp/Plugins/UserPlugin/PluginApp.UserPlugin.csproj
-       dotnet build ./samples/Example.PluginApp/Plugins/HelloPlugin/PluginApp.HelloPlugin.csproj
-       dotnet test ./samples/Example.PluginApp/Test/PluginApp.Host.Tests.csproj
+       dotnet build ./samples/Example.PluginApp/Plugins/EmployeePlugin/PluginApp.EmployeePlugin.csproj -c Release
+       dotnet build ./samples/Example.PluginApp/Plugins/UserPlugin/PluginApp.UserPlugin.csproj -c Release
+       dotnet build ./samples/Example.PluginApp/Plugins/HelloPlugin/PluginApp.HelloPlugin.csproj -c Release
+       dotnet test ./samples/Example.PluginApp/Test/PluginApp.Host.Tests.csproj -c Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,7 +26,7 @@ jobs:
        dotnet test ./tests/YeSql.Net.Tests.csproj
        dotnet test ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj
        dotnet publish ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj -c Debug -o out
-       dotnet vstest ./samples/Example.AspNetCore.Tests/out/Example.AspNetCore.Tests.dll
+       dotnet vstest ./out/Example.AspNetCore.Tests.dll
        dotnet build ./samples/Example.PluginApp/Plugins/EmployeePlugin/PluginApp.EmployeePlugin.csproj
        dotnet build ./samples/Example.PluginApp/Plugins/UserPlugin/PluginApp.UserPlugin.csproj
        dotnet build ./samples/Example.PluginApp/Plugins/HelloPlugin/PluginApp.HelloPlugin.csproj

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -25,6 +25,8 @@ jobs:
       run: |
        dotnet test ./tests/YeSql.Net.Tests.csproj
        dotnet test ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj
+       dotnet publish ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj -c Debug -o out
+       dotnet vstest ./samples/Example.AspNetCore.Tests/out/Example.AspNetCore.Tests.dll
        dotnet build ./samples/Example.PluginApp/Plugins/EmployeePlugin/PluginApp.EmployeePlugin.csproj
        dotnet build ./samples/Example.PluginApp/Plugins/UserPlugin/PluginApp.UserPlugin.csproj
        dotnet build ./samples/Example.PluginApp/Plugins/HelloPlugin/PluginApp.HelloPlugin.csproj


### PR DESCRIPTION
This pull request has been created to check if the nuget package called [CopySqlFilesToOutputDirectory](https://www.nuget.org/packages/CopySqlFilesToOutputDirectory) also copies the SQL files to the publish directory when using the **dotnet publish** command.

These two lines do the checking:
```sh
dotnet publish ./samples/Example.AspNetCore.Tests/Example.AspNetCore.Tests.csproj -c Release -o out
dotnet vstest ./out/Example.AspNetCore.Tests.dll
```