### PR TITLE
refactor: Use ref structure types

### DIFF
--- a/src/Common/Results/ResultOfT.cs
+++ b/src/Common/Results/ResultOfT.cs
@@ -4,7 +4,7 @@
 /// Represents the result of an operation.
 /// </summary>
 /// <typeparam name="T">A value associated to the result.</typeparam>
-internal readonly struct Result<T>
+internal readonly ref struct Result<T>
 {
     /// <summary>
     /// Gets the value associated with the result.

--- a/src/Parser/Line.cs
+++ b/src/Parser/Line.cs
@@ -3,7 +3,7 @@ namespace YeSql.Net;
 /// <summary>
 /// Represents a line of text from a file.
 /// </summary>
-internal readonly struct Line
+internal readonly ref struct Line
 {
     /// <summary>
     /// Gets the number/position of the line.


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct

> Instances of a ref struct type are allocated on the stack and can't escape to the managed heap. 