### PR TITLE
refactor: Create guard clauses

### DIFF
--- a/src/Common/ThrowHelper.cs
+++ b/src/Common/ThrowHelper.cs
@@ -1,0 +1,43 @@
+﻿namespace YeSql.Net;
+
+/// <summary>
+/// Helper methods to efficiently throw exceptions.
+/// </summary>
+internal class ThrowHelper
+{
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <c>argument</c> is <c>null</c>.
+    /// </summary>
+    /// <param name="argument">
+    /// The reference type argument to validate as non-null.
+    /// </param>
+    /// <param name="paramName">
+    /// The name of the parameter with which argument corresponds.
+    /// </param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static void ThrowIfNull(object argument, string paramName)
+    {
+        if (argument is null)
+            throw new ArgumentNullException(paramName);
+    }
+
+    /// <summary>
+    /// Throws an exception if the <paramref name="argument"/> contains elements with a null value, 
+    /// an empty string, or consists only of white-space characters.
+    /// </summary>
+    /// <param name="argument">
+    /// The collection argument to validate.
+    /// </param>
+    /// <param name="paramName">
+    /// The name of the parameter with which argument corresponds.
+    /// </param>
+    /// <exception cref="ArgumentException"></exception>
+    public static void ThrowIfContainsNullOrWhiteSpace(IEnumerable<string> argument, string paramName)
+    {
+        if (argument.ContainsNullOrWhiteSpace())
+        {
+            var message = string.Format(ExceptionMessages.CollectionHasNullValueOrOnlyWhitespace, paramName);
+            throw new ArgumentException(message);
+        }
+    }
+}

--- a/src/Loader/YeSqlLoader.cs
+++ b/src/Loader/YeSqlLoader.cs
@@ -60,15 +60,11 @@ public partial class YeSqlLoader
     /// </exception>
     public ISqlCollection LoadFromFiles(params string[] sqlFiles)
     {
-        if (sqlFiles is null)
-            throw new ArgumentNullException(nameof(sqlFiles));
-
+        ThrowHelper.ThrowIfNull(sqlFiles, nameof(sqlFiles));
         if (sqlFiles.IsEmpty())
             return _parser.SqlStatements;
-      
-        if (sqlFiles.ContainsNullOrWhiteSpace())
-            throw new ArgumentException(string.Format(ExceptionMessages.CollectionHasNullValueOrOnlyWhitespace, nameof(sqlFiles)));
 
+        ThrowHelper.ThrowIfContainsNullOrWhiteSpace(sqlFiles, nameof(sqlFiles));
         foreach (var fileName in sqlFiles)
         {
             Result<SqlFile> result = LoadFromFile(fileName);
@@ -103,15 +99,11 @@ public partial class YeSqlLoader
     /// </exception>
     public ISqlCollection LoadFromDirectories(params string[] directories)
     {
-        if (directories is null)
-            throw new ArgumentNullException(nameof(directories));
-
+        ThrowHelper.ThrowIfNull(directories, nameof(directories));
         if (directories.IsEmpty())
             return _parser.SqlStatements;
 
-        if(directories.ContainsNullOrWhiteSpace())
-            throw new ArgumentException(string.Format(ExceptionMessages.CollectionHasNullValueOrOnlyWhitespace, nameof(directories)));
-
+        ThrowHelper.ThrowIfContainsNullOrWhiteSpace(directories, nameof(directories));
         foreach (var directory in directories)
         {
             Result<IEnumerable<SqlFile>> result = LoadFromDirectory(directory);

--- a/src/Parser/YeSqlParser.cs
+++ b/src/Parser/YeSqlParser.cs
@@ -85,9 +85,7 @@ public partial class YeSqlParser
     /// </exception>
     public ISqlCollection Parse(string source, out YeSqlValidationResult validationResult)
     {
-        if(source is null)
-            throw new ArgumentNullException(nameof(source));
-
+        ThrowHelper.ThrowIfNull(source, nameof(source));
         validationResult = ValidationResult;
         if(string.IsNullOrWhiteSpace(source))
         {

--- a/src/Reader/YeSqlDictionary.cs
+++ b/src/Reader/YeSqlDictionary.cs
@@ -18,9 +18,7 @@ internal class YeSqlDictionary : ISqlCollection
     {
         get
         {
-            if(tagName is null)
-                throw new ArgumentNullException(nameof(tagName));
-
+            ThrowHelper.ThrowIfNull(tagName, nameof(tagName));
             if(_sqlStatements.TryGetValue(tagName, out var sqlStatement))
                 return sqlStatement;
 
@@ -35,9 +33,7 @@ internal class YeSqlDictionary : ISqlCollection
     /// <inheritdoc />
     public bool TryGetStatement(string tagName, out string sqlStatement)
     {
-        if (tagName is null)
-            throw new ArgumentNullException(nameof(tagName));
-
+        ThrowHelper.ThrowIfNull(tagName, nameof (tagName));
         return _sqlStatements.TryGetValue(tagName, out sqlStatement);
     }
 


### PR DESCRIPTION
**ThrowHelper API has been created for several reasons:**
- Makes consumer code as simple as possible.
- It reduces repetitive null checks, so it can be encapsulated in helper methods.
- Reduces the size of the code generated by the JIT. 
  See https://learn.microsoft.com/en-us/dotnet/communitytoolkit/diagnostics/throwhelper#technical-details
- Avoid cause substantial [instruction-cache pollution](https://en.wikipedia.org/wiki/Cache_pollution).
   See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1510#rule-description