### PR TITLE
Fix base directory resolution for custom hosting environments

### DIFF
--- a/src/Loader/PathResolver.cs
+++ b/src/Loader/PathResolver.cs
@@ -1,0 +1,18 @@
+﻿namespace YeSql.Net;
+
+internal class PathResolver
+{
+    public static string BaseDirectory
+    {
+        get
+        {
+            // AppContext.BaseDirectory may not be available in all hosting
+            // environments (e.g. SampSharp/open.mp). Fall back to the current
+            // working directory when necessary.
+            if (!string.IsNullOrWhiteSpace(AppContext.BaseDirectory))
+                return AppContext.BaseDirectory;
+
+            return Directory.GetCurrentDirectory();
+        }
+    }
+}

--- a/src/Loader/YeSqlLoader.HelperMethods.cs
+++ b/src/Loader/YeSqlLoader.HelperMethods.cs
@@ -36,7 +36,7 @@ public partial class YeSqlLoader
     {
         var path = Path.IsPathRooted(file) ? 
             file : 
-            Path.Combine(AppContext.BaseDirectory, file);
+            Path.Combine(PathResolver.BaseDirectory, file);
 
         if (HasNotSqlExtension(path))
         {
@@ -80,7 +80,7 @@ public partial class YeSqlLoader
     {
         var path = Path.IsPathRooted(directoryName) ?
             directoryName :
-            Path.Combine(AppContext.BaseDirectory, directoryName);
+            Path.Combine(PathResolver.BaseDirectory, directoryName);
 
         if (!Directory.Exists(path))
         {

--- a/tests/Loader/YeSqlLoaderTests.Directories.cs
+++ b/tests/Loader/YeSqlLoaderTests.Directories.cs
@@ -115,7 +115,7 @@ public partial class YeSqlLoaderTests
     {
         // Arrange
         var loader = new YeSqlLoader();
-        var absolutePath = Path.Combine(AppContext.BaseDirectory, "sql");
+        var absolutePath = Path.Combine(PathResolver.BaseDirectory, "sql");
         var expectedCollection = new Dictionary<string, string>
         {
             { "GetUsers", "SELECT* FROM [user];" }

--- a/tests/Loader/YeSqlLoaderTests.Files.cs
+++ b/tests/Loader/YeSqlLoaderTests.Files.cs
@@ -83,7 +83,7 @@ public partial class YeSqlLoaderTests
     {
         // Arrange
         var loader = new YeSqlLoader();
-        var absolutePath = Path.Combine(AppContext.BaseDirectory, "sql/users.sql");
+        var absolutePath = Path.Combine(PathResolver.BaseDirectory, "sql/users.sql");
         var expectedCollection = new Dictionary<string, string>
         {
             { "GetUsers", "SELECT* FROM [user];" }


### PR DESCRIPTION
## Summary

This change introduces a `PathResolver` utility to centralize base directory resolution used when locating SQL files.

Previously, YeSQL.Net relied directly on `AppContext.BaseDirectory` when resolving SQL file locations. While this works in most .NET hosting scenarios, it does not behave reliably under SampSharp/open.mp hosting.

The new implementation falls back to `Directory.GetCurrentDirectory()` when `AppContext.BaseDirectory` is unavailable, providing a more resilient path resolution strategy.

## Motivation

While migrating a game mode to [SampSharp.OpenMp.Entities](https://github.com/ikkentim/SampSharp), SQL files could not be located correctly because `AppContext.BaseDirectory` was not available as expected.

According to SampSharp maintainer Tim Potze:

> Due to technical limitations of dotnet it's not possible to set the AppContext.BaseDirectory.

As a result, libraries that assume `AppContext.BaseDirectory` is always available may fail in custom hosting environments.

## Changes

* Added `PathResolver` utility class.
* Centralized base directory resolution logic.
* Added fallback to `Directory.GetCurrentDirectory()`.
* Replaced direct usages of `AppContext.BaseDirectory` with `PathResolver.BaseDirectory`.

## Benefits

* Improved compatibility with non-standard hosting environments.
* Preserves existing behavior for standard .NET applications.
* Provides a single place to maintain path resolution logic.
* Improves reliability when locating SQL files.
